### PR TITLE
temp table in NZ allow database specification

### DIFF
--- a/dbt/include/netezza/macros/adapters.sql
+++ b/dbt/include/netezza/macros/adapters.sql
@@ -26,7 +26,7 @@
   {{ sql_header if sql_header is not none }}
 
   create {% if temporary -%}temporary{%- endif %} table
-    {{ relation.include(database=(not temporary), schema=(not temporary)) }}
+    {{ relation }}
   as (
     {{ sql }}
   )


### PR DESCRIPTION
Without this change, default incremental materialization throws an error when using custom databases