### PR TITLE
Add rowcount and upgrade to dbt-core 1.2

### DIFF
--- a/dbt/adapters/netezza/connections.py
+++ b/dbt/adapters/netezza/connections.py
@@ -140,10 +140,7 @@ class NetezzaConnectionManager(connection_cls):
         that has items such as code, rows_affected, etc. can also just be a string ex. "OK"
         if your cursor does not offer rich metadata.
         """
-        if not len(cursor.messages):
-            return "OK"
-        last_code, last_message = cursor.messages[-1]
-        return AdapterResponse(last_message, last_code, cursor.rowcount)
+        return AdapterResponse(_message=f"SUCCESS {cursor.rowcount}", code="SUCCESS", rows_affected=cursor.rowcount)
 
     def cancel(self, connection):
         """

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        'dbt-core~=1.1.0',
+        'dbt-core~=1.2.0',
         'pyodbc~=4.0'
     ]
 )


### PR DESCRIPTION
I tested and the adapter as-is fully works also with dbt-core 1.2.
I additionally did a small change on connections.py to add in the log the number of rows processed (like dbt-snowflake does).